### PR TITLE
Removed addFlags code

### DIFF
--- a/app/src/main/java/com/axanor/saf_sample/MainActivity.kt
+++ b/app/src/main/java/com/axanor/saf_sample/MainActivity.kt
@@ -46,11 +46,6 @@ class MainActivity : AppCompatActivity() {
     // this will present the user with folder browser to select a folder for our data
     private fun askPermission() {
         val intent = Intent(Intent.ACTION_OPEN_DOCUMENT_TREE)
-        intent.addFlags(
-                Intent.FLAG_GRANT_READ_URI_PERMISSION
-                        or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
-                        or Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION
-                        or Intent.FLAG_GRANT_PREFIX_URI_PERMISSION)
         startActivityForResult(intent, REQUEST_CODE)
     }
 


### PR DESCRIPTION
addFlags is not required for requesting access to content. Its only used when granting other apps access to content when starting an activity for ACTION_VIEW etc. 

For reference - this answer by CommonsWare - https://stackoverflow.com/a/68593690/3090120